### PR TITLE
Production tms geometry study

### DIFF
--- a/examples/submit_TMSGeometryStudy.sh
+++ b/examples/submit_TMSGeometryStudy.sh
@@ -1,0 +1,40 @@
+#!/usr/bin/env bash
+
+
+set +o posix
+
+
+#scripts/load_yaml.py specs/SimForNDLAr_v4.yaml specs/TMSGeometryStudy_1E18_FHC/*.genie.nu.yaml --replace
+#scripts/load_yaml.py specs/SimForNDLAr_v4.yaml specs/TMSGeometryStudy_1E18_FHC/*.edep.nu.yaml --replace
+#scripts/load_yaml.py specs/SimForNDLAr_v4.yaml specs/TMSGeometryStudy_1E18_FHC/*.hadd.nu.yaml --replace
+#scripts/load_yaml.py specs/SimForNDLAr_v4.yaml specs/TMSGeometryStudy_1E18_FHC/*.spill.nu.yaml --replace
+#scripts/load_yaml.py specs/ND_Production_v1.yaml specs/TMSGeometryStudy_1E18_FHC/*.tmsreco.nu.yaml --replace
+
+
+start=1
+single_size=2560
+spill_size=256
+
+# hybrid or stereo geometry. 
+logdir=/pscratch/sd/m/mdolce/TMSGeometryStudy_1E18_FHC-stereo/logs_sbatch
+mkdir -p $logdir
+
+
+#scripts/fwsub.py --runner SimForNDLAr_v4_Genie --base-env TMSGeometryStudy_1E18_FHC.genie.nu --size $single_size --start $start
+#sbatch -o ${logdir:-.}/slurm-%j.txt --array=1-5 -N 1 slurm/fw_cpu.slurm.sh TMSGeometryStudy_1E18_FHC.genie.nu rapidfire
+
+
+#scripts/fwsub.py --runner SimForNDLAr_v4_Edep --base-env TMSGeometryStudy_1E18_FHC.edep.nu --size $single_size --start $start
+#sbatch -o ${logdir:-.}/slurm-%j.txt --array=1-2 -N 1 slurm/fw_cpu.slurm.sh TMSGeometryStudy_1E18_FHC.edep.nu rapidfire
+
+
+#scripts/fwsub.py --runner SimForNDLAr_v4_Hadd --base-env TMSGeometryStudy_1E18_FHC.nu.hadd --size $spill_size --start $start
+#sbatch -o ${logdir:-.}/slurm-%j.txt --array=1-1 -N 1 slurm/fw_cpu.slurm.sh TMSGeometryStudy_1E18_FHC.nu.hadd rapidfire
+
+
+#scripts/fwsub.py --runner SimForNDLAr_v4_SpillBuild --base-env TMSGeometryStudy_1E18_FHC.spill.nu --size $spill_size --start $start
+#sbatch -o ${logdir:-.}/slurm-%j.txt --array=1-1 -N 1 slurm/fw_cpu.slurm.sh TMSGeometryStudy_1E18_FHC.spill.nu rapidfire
+
+
+#scripts/fwsub.py --runner ND_Production_v1_TMSReco --base-env TMSGeometryStudy_1E18_FHC.tmsreco.nu --size $spill_size --start $start
+#sbatch -o ${logdir:-.}/slurm-%j.txt --array=1-1 -N 1 slurm/fw_cpu.slurm.sh TMSGeometryStudy_1E18_FHC.tmsreco.nu rapidfire

--- a/specs/TMSGeometryStudy_1E18_FHC/TMSGeometryStudy_1E18_FHC.edep.nu.yaml
+++ b/specs/TMSGeometryStudy_1E18_FHC/TMSGeometryStudy_1E18_FHC.edep.nu.yaml
@@ -1,0 +1,10 @@
+base_envs:
+  - name: 'TMSGeometryStudy_1E18_FHC.edep.nu'
+    env:
+      ARCUBE_CONTAINER: 'mjkramer/sim2x2:ndlar011'
+      ARCUBE_EDEP_MAC: 'macros/dune-nd.mac'
+      ARCUBE_GENIE_NAME: 'TMSGeometryStudy_1E18_FHC.genie.nu'
+      ARCUBE_GEOM: 'geometry/TMSGeometryStudy/nd_hall_with_lar_tms-stereo_sand.gdml'
+      ARCUBE_LOGDIR_BASE: '/pscratch/sd/m/mdolce/TMSGeometryStudy_1E18_FHC-stereo/logs'
+      ARCUBE_OUTDIR_BASE: '/pscratch/sd/m/mdolce/TMSGeometryStudy_1E18_FHC-stereo/output'
+      ARCUBE_RUNTIME: 'SHIFTER'

--- a/specs/TMSGeometryStudy_1E18_FHC/TMSGeometryStudy_1E18_FHC.genie.nu.yaml
+++ b/specs/TMSGeometryStudy_1E18_FHC/TMSGeometryStudy_1E18_FHC.genie.nu.yaml
@@ -1,0 +1,15 @@
+base_envs:
+  - name: 'TMSGeometryStudy_1E18_FHC.genie.nu'
+    env:
+      ARCUBE_CONTAINER: 'mjkramer/sim2x2:genie_edep.3_04_00.20230620'
+      ARCUBE_DET_LOCATION: 'DUNEND'
+      ARCUBE_DK2NU_DIR: '/dvs_ro/cfs/cdirs/dune/users/abooth/fluxfiles/DUNE_PRISM/OnAxis/neutrino/dk2nu'
+      ARCUBE_EXPOSURE: '1E15'
+      ARCUBE_GEOM: 'geometry/TMSGeometryStudy/nd_hall_with_lar_tms-stereo_sand.gdml'
+      ARCUBE_LOGDIR_BASE: '/pscratch/sd/m/mdolce/TMSGeometryStudy_1E18_FHC-stereo/logs'
+      ARCUBE_OUTDIR_BASE: '/pscratch/sd/m/mdolce/TMSGeometryStudy_1E18_FHC-stereo/output'
+      ARCUBE_RUNTIME: 'SHIFTER'
+      ARCUBE_TOP_VOLUME: 'volArgonCubeDetector75'
+      ARCUBE_TUNE: 'AR23_20i_00_000'
+      ARCUBE_XSEC_FILE: '/dvs_ro/cfs/cdirs/dune/users/2x2EventGeneration/inputs/NuMI/genie_xsec-3.04.00-noarch-AR2320i00000-k250-e1000/v3_04_00/NULL/AR2320i00000-k250-e1000/data/gxspl-NUsmall.xml'
+      ARCUBE_ZMIN: '-3'

--- a/specs/TMSGeometryStudy_1E18_FHC/TMSGeometryStudy_1E18_FHC.hadd.nu.yaml
+++ b/specs/TMSGeometryStudy_1E18_FHC/TMSGeometryStudy_1E18_FHC.hadd.nu.yaml
@@ -1,0 +1,10 @@
+base_envs:
+  - name: 'TMSGeometryStudy_1E18_FHC.nu.hadd'
+    env:
+      ARCUBE_CONTAINER: 'mjkramer/sim2x2:ndlar011'
+      ARCUBE_IN_NAME: 'TMSGeometryStudy_1E18_FHC.edep.nu'
+      ARCUBE_HADD_FACTOR: '10'
+      ARCUBE_LOGDIR_BASE: '/pscratch/sd/m/mdolce/TMSGeometryStudy_1E18_FHC-stereo/logs'
+      ARCUBE_OUTDIR_BASE: '/pscratch/sd/m/mdolce/TMSGeometryStudy_1E18_FHC-stereo/output'
+      ARCUBE_RUNTIME: 'SHIFTER'
+      ARCUBE_USE_GHEP_POT: '1'

--- a/specs/TMSGeometryStudy_1E18_FHC/TMSGeometryStudy_1E18_FHC.spill.nu.yaml
+++ b/specs/TMSGeometryStudy_1E18_FHC/TMSGeometryStudy_1E18_FHC.spill.nu.yaml
@@ -1,0 +1,12 @@
+base_envs:
+  - name: 'TMSGeometryStudy_1E18_FHC.spill.nu'
+    env:
+      ARCUBE_CONTAINER: 'mjkramer/sim2x2:ndlar011'
+      ARCUBE_LOGDIR_BASE: '/pscratch/sd/m/mdolce/TMSGeometryStudy_1E18_FHC-stereo/logs'
+      ARCUBE_NU_NAME: 'TMSGeometryStudy_1E18_FHC.nu.hadd'
+      ARCUBE_NU_POT: '1E16'
+      ARCUBE_OUTDIR_BASE: '/pscratch/sd/m/mdolce/TMSGeometryStudy_1E18_FHC-stereo/output'
+      ARCUBE_ROCK_NAME: 'TMSGeometryStudy_1E18_FHC.rock.hadd'
+      ARCUBE_ROCK_POT: '0'
+      ARCUBE_RUNTIME: 'SHIFTER'
+      ARCUBE_SPILL_POT: '7.5E13'

--- a/specs/TMSGeometryStudy_1E18_FHC/TMSGeometryStudy_1E18_FHC.tmsreco.nu.yaml
+++ b/specs/TMSGeometryStudy_1E18_FHC/TMSGeometryStudy_1E18_FHC.tmsreco.nu.yaml
@@ -1,0 +1,8 @@
+base_envs:
+  - name: 'TMSGeometryStudy_1E18_FHC.tmsreco.nu'
+    env:
+      ND_PRODUCTION_CONTAINER: 'fermilab/fnal-wn-sl7:latest'
+      ND_PRODUCTION_LOGDIR_BASE: '/pscratch/sd/m/mdolce/TMSGeometryStudy_1E18_FHC-stereo/logs'
+      ND_PRODUCTION_OUTDIR_BASE: '/pscratch/sd/m/mdolce/TMSGeometryStudy_1E18_FHC-stereo/output'
+      ND_PRODUCTION_SPILL_NAME: 'TMSGeometryStudy_1E18_FHC.spill.nu'
+      ND_PRODUCTION_RUNTIME: 'SHIFTER'


### PR DESCRIPTION
Recently completed a production request for TMS group. Requested TMS reco files using two different geometry files: `nd_hall_with_lar_tms-stereo_sand.gdml` and `nd_hall_with_lar_tms-hybrid_sand.gdml` (a stereo vs a hybrid design). This PR is mainly for booking-keeping, contains the two items I used to produce this sample: 

* a `specs/TMSGeometry_Study_1E18_FHC` directory of the yaml files for each step of the generation. 
* the `examples/submit_TMSGeometry_Study.sh` bash script which contains the loading of the yaml file and the slurm submission for all steps of the production chain. 

Note: the two `gdml` files are _not_ in this repo, *and* the stereo geometry file is currently written in the yaml files. (One would need to change this to the hybrid `gdml` file, if that is what they want to produce)