### PR TITLE
Add FSD Cosmic workflow to fireworks

### DIFF
--- a/examples/submit.FSD_CosmicRun1.sh
+++ b/examples/submit.FSD_CosmicRun1.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+
+source admin/load_fireworks.sh
+set +o posix                    # sneaky sneaky, NERSC
+
+name=CosmicRun
+logdir=$SCRATCH/logs.$name
+export FW4DUNE_SLEEP_SEC=30
+
+scripts/load_yaml.py --replace specs/SimFor2x2_v6.yaml specs/$name/*.yaml
+
+mkdir -p "$logdir"
+
+workflows/fwsub.FSD_CosmicRun1.py
+
+# additional time to delay start of jobs with dependencies
+START_DELAY=30 # minutes
+
+# CORSIKA, edep-sim, convert2h5
+sbatch --parsable -o "$logdir"/slurm-%j.txt -N 1 -t 30 slurm/fw_cpu.slurm.sh cpu_seconds rapidfire
+
+# larnd-sim, spine
+GPU_MIN_JOBID=$(sbatch --parsable -C "gpu&hbm80g" \
+    -o "$logdir"/slurm-%j.txt -N 2 -t 120 slurm/fw_gpu.slurm.sh gpu_minutes rapidfire)
+    # -o "$logdir"/slurm-%j.txt --array=1-1  -N 4 -t 150 slurm/fw_gpu.slurm.sh gpu_minutes rapidfire)
+
+# nd-flow, flow2supera, cafs
+CPU_MIN_JOBID=$(sbatch --parsable -d after:$GPU_MIN_JOBID+$START_DELAY \
+    -o "$logdir"/slurm-%j.txt -N 1 -t 60 slurm/fw_cpu.slurm.sh cpu_minutes rapidfire)
+    # -o "$logdir"/slurm-%j.txt --array=1-5 -N 2 -t 60 slurm/fw_cpu.slurm.sh cpu_minutes rapidfire)

--- a/specs/FSD_CosmicRun1/FSD_CosmicRun1.convert2h5.yaml
+++ b/specs/FSD_CosmicRun1/FSD_CosmicRun1.convert2h5.yaml
@@ -1,0 +1,10 @@
+base_envs:
+  - name: 'FSD_CosmicRun1.convert2h5'
+    env:
+      ARCUBE_OUTDIR_BASE: '/pscratch/sd/c/cuddandr/output/FSD_CosmicRun1'
+      ARCUBE_LOGDIR_BASE: '/pscratch/sd/c/cuddandr/logs/FSD_CosmicRun1'
+      ARCUBE_RUNTIME: 'SHIFTER'
+      ARCUBE_CONTAINER: 'mjkramer/sim2x2:ndlar011'
+      ARCUBE_ACTIVE_VOLUME: 'volTPCActive'
+      ARCUBE_SINGLE_NAME: 'FSD_CosmicRun1.edep'
+      ARCUBE_KEEP_ALL_DETS: '0'

--- a/specs/FSD_CosmicRun1/FSD_CosmicRun1.corsika.yaml
+++ b/specs/FSD_CosmicRun1/FSD_CosmicRun1.corsika.yaml
@@ -1,0 +1,9 @@
+base_envs:
+  - name: 'FSD_CosmicRun1.corsika'
+    env:
+      ARCUBE_OUTDIR_BASE: '/pscratch/sd/c/cuddandr/output/FSD_CosmicRun1'
+      ARCUBE_LOGDIR_BASE: '/pscratch/sd/c/cuddandr/logs/FSD_CosmicRun1'
+      ARCUBE_RUNTIME: 'SHIFTER'
+      ARCUBE_CONTAINER: 'mjkramer/sim2x2:ndlar011'
+      ARCUBE_LOC: 'BERN'
+      ARCUBE_NSHOW: '10000'

--- a/specs/FSD_CosmicRun1/FSD_CosmicRun1.edep.yaml
+++ b/specs/FSD_CosmicRun1/FSD_CosmicRun1.edep.yaml
@@ -1,0 +1,11 @@
+base_envs:
+  - name: 'FSD_CosmicRun1.edep'
+    env:
+      ARCUBE_OUTDIR_BASE: '/pscratch/sd/c/cuddandr/output/FSD_CosmicRun1'
+      ARCUBE_LOGDIR_BASE: '/pscratch/sd/c/cuddandr/logs/FSD_CosmicRun1'
+      ARCUBE_SIM: 'CORSIKA'
+      ARCUBE_RUNTIME: 'SHIFTER'
+      ARCUBE_CONTAINER: 'mjkramer/sim2x2:ndlar011'
+      ARCUBE_CORSIKA_NAME: 'FSD_CosmicRun1.corsika'
+      ARCUBE_EDEP_MAC: 'macros/cosmics.mac'
+      ARCUBE_GEOM_EDEP: 'geometry/fsd_with_cryostat.gdml'

--- a/specs/FSD_CosmicRun1/FSD_CosmicRun1.flow.yaml
+++ b/specs/FSD_CosmicRun1/FSD_CosmicRun1.flow.yaml
@@ -1,0 +1,8 @@
+base_envs:
+  - name: 'FSD_CosmicRun1.flow'
+    env:
+      ARCUBE_RUNTIME: 'NONE'
+      ARCUBE_OUTDIR_BASE: '/pscratch/sd/c/cuddandr/output/FSD_CosmicRun1'
+      ARCUBE_LOGDIR_BASE: '/pscratch/sd/c/cuddandr/logs/FSD_CosmicRun1'
+      ARCUBE_IN_NAME: 'FSD_CosmicRun1.larnd'
+      ARCUBE_COMPRESS: 'lzf'

--- a/specs/FSD_CosmicRun1/FSD_CosmicRun1.larnd.yaml
+++ b/specs/FSD_CosmicRun1/FSD_CosmicRun1.larnd.yaml
@@ -1,0 +1,8 @@
+base_envs:
+  - name: 'FSD_CosmicRun1.larnd'
+    env:
+      ARCUBE_OUTDIR_BASE: '/pscratch/sd/c/cuddandr/output/FSD_CosmicRun1'
+      ARCUBE_LOGDIR_BASE: '/pscratch/sd/c/cuddandr/logs/FSD_CosmicRun1'
+      ARCUBE_RUNTIME: 'NONE'
+      ARCUBE_CONVERT2H5_NAME: 'FSD_CosmicRun1.convert2h5'
+      ARCUBE_LARNDSIM_CONFIG: 'fsd'

--- a/specs/SimFor2x2_v6.yaml
+++ b/specs/SimFor2x2_v6.yaml
@@ -8,6 +8,11 @@ runners:
     workdir: 'run-genie'
     cmd: './run_genie.sh'
 
+  - name: 'SimFor2x2_v6_Corsika'
+    repo: 'SimFor2x2_v6'
+    workdir: 'run-corsika'
+    cmd: './run_both_steps.sh'
+
   - name: 'SimFor2x2_v6_Edep'
     repo: 'SimFor2x2_v6'
     workdir: 'run-edep-sim'

--- a/workflows/fwsub.FSD_CosmicRun1.py
+++ b/workflows/fwsub.FSD_CosmicRun1.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+
+import argparse
+
+from typing import Optional
+
+from fireworks import Firework, LaunchPad, Workflow
+
+from fw4dune_tasks import RepoRunner
+
+HADD_FACTOR = 10
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument('--base-env-prefix', default='FSD_CosmicRun1')
+    ap.add_argument('--name', help='Defaults to --base-env-prefix')
+    ap.add_argument('--repo', default='SimFor2x2_v6')
+    ap.add_argument('--size', type=int, default=1024, help='Number of final outputs (post-hadd etc.) to produce')
+    ap.add_argument('--start', type=int, default=0, help='Starting index of output files')
+    args = ap.parse_args()
+
+    if args.name is None:
+        args.name = args.base_env_prefix
+
+    lpad = LaunchPad.auto_load()
+
+    def make_fw(index: int, runner_postfix: str, step_postfix: str,
+                category: Optional[str]) -> Firework:
+
+        base_env = f'{args.base_env_prefix}.{step_postfix}'
+        if category is None:
+            category = base_env
+
+        spec = {
+            'runner': f'{args.repo}_{runner_postfix}',
+            'base_env': base_env,
+            'env': {
+                'ARCUBE_OUT_NAME': f'{args.name}.{step_postfix}',
+                'ARCUBE_INDEX': str(index)
+            },
+            '_category': category
+        }
+
+        return Firework(RepoRunner(), name=f'{args.name}.{step_postfix}', spec=spec)
+
+    for i in range(args.start, args.start + args.size):
+        fw_corsika = make_fw(i, 'Corsika', 'corsika', category='cpu_seconds')
+        fw_edep = make_fw(i, 'Edep', 'edep', category='cpu_seconds')
+        fw_convert2h5 = make_fw(i, 'Convert2H5', 'convert2h5', category='cpu_seconds')
+        fw_larnd = make_fw(i, 'LArND', 'larnd', category='gpu_minutes')
+        fw_flow = make_fw(i, 'Flow', 'flow', category='cpu_minutes')
+
+        fireworks = [fw_corsika, fw_edep, fw_convert2h5,
+                     fw_larnd, fw_flow]
+
+        deps = {fw_corsika: [fw_edep],
+                fw_edep: [fw_convert2h5],
+                fw_convert2h5: [fw_larnd],
+                fw_larnd: [fw_flow]}
+
+        wf = Workflow(fireworks, deps, name=args.name)
+
+        lpad.add_wf(wf)
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
New specs, workflow submit, and job submit scripts for FSD cosmic simulation. Currently labelled as `FSD_CosmicRun1`, and possibly some parameters could be tuned, most likely the number of showers per CORSIKA file.

FSD cosmic production only includes steps up to and including nd-flow, including new CORSIKA stage. Does not include reco or CAFs.

The output/log directories in the specs yamls need to be updated (currently they point to my scratch space). Additionally the slurm parameters for number of nodes and time could use some further tuning, especially as we scale to larger file productions (the largest I submitted to the queue was 256 workflows at once).

2x2_sim will soon have (or already has) a corresponding pull request to include the CORSIKA step and other minor changes for cosmic running and backward compatibility. Still expect some crashes, but at this point we can start integrating everything while those get fixed.